### PR TITLE
Only test for warnings under AUTHOR_TESTING

### DIFF
--- a/t/sitemap.t
+++ b/t/sitemap.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 8;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 
 BEGIN { use_ok('WWW::SitemapIndex::XML::Sitemap') }
 
@@ -41,3 +42,8 @@ for my $args ( @invalid ) {
     } 'object not created with invalid args';
 }
 
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/types.t
+++ b/t/types.t
@@ -3,7 +3,8 @@ use warnings;
 
 use Test::More tests => 40;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 use URI;
 
 {
@@ -185,3 +186,9 @@ for my $p (qw( -1 2 10 )) {
         $o->priority( $p );
     } qr/Valid priority ranges from 0.0 to 1.0/, "$p is not a valid Priority";
 }
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/url.t
+++ b/t/url.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 10;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 
 BEGIN { use_ok('WWW::Sitemap::XML::URL') }
 
@@ -51,3 +52,9 @@ for my $args ( @invalid ) {
     } 'object not created with invalid args';
 }
 
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-add.t
+++ b/t/xml-add.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 31;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 use URI;
 
 BEGIN { use_ok('WWW::Sitemap::XML') };
@@ -149,3 +150,9 @@ SKIP: {
 };
 
 
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-as_xml.t
+++ b/t/xml-as_xml.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 8;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 
 BEGIN { use_ok('WWW::Sitemap::XML') };
 
@@ -45,3 +46,9 @@ sub _read_sitemap {
     close SITEMAP;
     return $xml;
 }
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-google-read.t
+++ b/t/xml-google-read.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 12;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 
 BEGIN { use_ok('WWW::Sitemap::XML') };
 
@@ -123,3 +124,9 @@ sub _read_sitemap {
     close SITEMAP;
     return $xml;
 }
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-idx-add.t
+++ b/t/xml-idx-add.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 31;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 use URI;
 
 BEGIN { use_ok('WWW::SitemapIndex::XML') };
@@ -131,3 +132,9 @@ SKIP: {
 };
 
 
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-idx-as_xml.t
+++ b/t/xml-idx-as_xml.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 8;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 
 BEGIN { use_ok('WWW::SitemapIndex::XML') };
 
@@ -45,3 +46,9 @@ sub _read_sitemapindex {
     close SITEMAP;
     return $xml;
 }
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-idx-load.t
+++ b/t/xml-idx-load.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 6;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 
 BEGIN { use_ok('WWW::SitemapIndex::XML') };
 
@@ -40,3 +41,9 @@ sub _read_sitemapindex {
     close SITEMAP;
     return $xml;
 }
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-idx-read.t
+++ b/t/xml-idx-read.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 7;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 
 BEGIN { use_ok('WWW::SitemapIndex::XML') };
 
@@ -54,3 +55,9 @@ sub _read_sitemapindex {
     close SITEMAP;
     return $xml;
 }
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-idx-write.t
+++ b/t/xml-idx-write.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 17;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 use IO::Zlib;
 use IO::File;
 
@@ -99,3 +100,9 @@ sub _read {
     return $xml;
 }
 
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-load.t
+++ b/t/xml-load.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 6;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 
 BEGIN { use_ok('WWW::Sitemap::XML') };
 
@@ -40,3 +41,9 @@ sub _read_sitemap {
     close SITEMAP;
     return $xml;
 }
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-read.t
+++ b/t/xml-read.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 9;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 
 BEGIN { use_ok('WWW::Sitemap::XML') };
 
@@ -78,3 +79,9 @@ sub _read_sitemap {
     close SITEMAP;
     return $xml;
 }
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};

--- a/t/xml-write.t
+++ b/t/xml-write.t
@@ -4,7 +4,8 @@ use warnings;
 
 use Test::More tests => 17;
 use Test::Exception;
-use Test::NoWarnings;
+use Test::NoWarnings qw(had_no_warnings);
+$Test::NoWarnings::do_end_test = 0;
 use IO::Zlib;
 use IO::File;
 
@@ -99,3 +100,9 @@ sub _read {
     return $xml;
 }
 
+
+SKIP: {
+    skip 'author testing', 1 unless ($ENV{'AUTHOR_TESTING'});
+
+    had_no_warnings;
+};


### PR DESCRIPTION
I think this is the best solution. Test::Warnings might be a little cleaner with an import option to disable the automatic end test.
