### PR TITLE
fix: Allow URI::SmartURI (and other) objects

### DIFF
--- a/lib/WWW/Sitemap/XML/Types.pm
+++ b/lib/WWW/Sitemap/XML/Types.pm
@@ -41,6 +41,8 @@ subtype Location,
     message { "$_ is not a valid URL" };
 
 coerce Location,
+    from Object,
+    via { qq($_) },
     from Uri,
     via { $_->as_string };
 

--- a/t/sitemap.t
+++ b/t/sitemap.t
@@ -2,21 +2,28 @@
 use strict;
 use warnings;
 
-use Test::More tests => 8;
+use Test::More;
 use Test::Exception;
 use Test::NoWarnings;
 
-BEGIN { use_ok('WWW::SitemapIndex::XML::Sitemap') }
 
 
 my $o;
+my @smart_uri_test = eval {
+    require URI::SmartURI;
+    { loc => URI::SmartURI->new('https://domain.test:8443/test/p') };
+};
 
 my @valid = (
+    @smart_uri_test ? @smart_uri_test : (),
+    {
+        loc => 'https://domain.test:8443/test/p',
+    },
     {
         loc => 'http://www.mywebsite.com/sitemap1.xml.gz',
     },
     {
-        loc => 'http://www.mywebsite.com/sitemap1.xml.gz?source=google',
+        loc     => 'http://www.mywebsite.com/sitemap1.xml.gz?source=google',
         lastmod => time(),
     }
 );
@@ -27,6 +34,13 @@ my @invalid = (
         lastmod => 'now',
     },
 );
+
+plan tests => 1     # use_ok
+    + 1             # "no warnings"
+    + 2 * @valid    # two tests per valid entry
+    + @invalid;     # one test per invalid entry
+
+use_ok('WWW::SitemapIndex::XML::Sitemap');
 
 for my $args ( @valid ) {
     lives_ok {
@@ -40,4 +54,3 @@ for my $args ( @invalid ) {
         $o = WWW::SitemapIndex::XML::Sitemap->new(%$args);
     } 'object not created with invalid args';
 }
-

--- a/t/url.t
+++ b/t/url.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 10;
+use Test::More tests => 12;
 use Test::Exception;
 use Test::NoWarnings;
 
@@ -12,6 +12,9 @@ BEGIN { use_ok('WWW::Sitemap::XML::URL') }
 my $o;
 
 my @valid = (
+    {
+        loc => 'https://domain.test:8443/test/p',
+    },
     {
         loc => 'http://www.mywebsite.com/friendly_url.html?name=Alex%20J.%20G.%20Burzyński',
     },


### PR DESCRIPTION
We use the SmartURI plugin in our Catalyst app. The creation of the sitemap fails for a type constraint:

`Unable to render sitemap: Attribute (loc) does not pass the type constraint because: https://portal.test:8443/test/service-pin is not a valid URL at constructor WWW::Sitemap::XML::URL::new`

This was surprising at the first glance.
My proposal is another simple coercion from objects by simply stringifying them.