### PR TITLE
Remove the maximum length from video titles

### DIFF
--- a/lib/WWW/Sitemap/XML/Google/Video.pm
+++ b/lib/WWW/Sitemap/XML/Google/Video.pm
@@ -4,7 +4,7 @@ use warnings;
 package WWW::Sitemap::XML::Google::Video;
 
 use Moose;
-use WWW::Sitemap::XML::Types qw( Location VideoPlayer Max100CharsStr Max2048CharsStr );
+use WWW::Sitemap::XML::Types qw( Location VideoPlayer NonEmptyStr Max2048CharsStr );
 use XML::LibXML;
 
 =head1 SYNOPSIS
@@ -94,7 +94,7 @@ has 'player' => (
 
 The title of the video.
 
-isa: L<WWW::Sitemap::XML::Types/"Max100CharsStr">
+isa: L<WWW::Sitemap::XML::Types/"NonEmptyStr">
 
 Required.
 
@@ -102,7 +102,7 @@ Required.
 
 has 'title' => (
     is => 'rw',
-    isa => Max100CharsStr,
+    isa => NonEmptyStr,
     required => 1,
     predicate => 'has_title',
 );
@@ -195,4 +195,3 @@ L<https://support.google.com/webmasters/answer/183668>
 __PACKAGE__->meta->make_immutable;
 
 1;
-

--- a/lib/WWW/Sitemap/XML/Types.pm
+++ b/lib/WWW/Sitemap/XML/Types.pm
@@ -18,7 +18,7 @@ use MooseX::Types -declare => [qw(
     ImageObject
     ArrayRefOfImageObjects
     StrBool
-    Max100CharsStr
+    NonEmptyStr
     Max2048CharsStr
 )];
 
@@ -55,12 +55,12 @@ coerce LowercaseStr,
     from Str,
     via { lc($_) };
 
-subtype Max100CharsStr,
+subtype NonEmptyStr,
     as Str,
     where {
-        length($_) <= 100
+        length($_) > 0
     },
-    message { "Maximum of 100 characters allowed" };
+    message { "Must be non-empty" };
 
 subtype Max2048CharsStr,
     as Str,
@@ -241,14 +241,14 @@ Subtype of C<Str>, with only lowercase characters.
 
 Coerces from C<Str> using C<lc>.
 
-=type Max100CharsStr
+=type NonEmptyStr
 
     has 'short_str' => (
         is => 'rw',
-        isa => Max100CharsStr,
+        isa => NonEmptyStr,
     );
 
-Subtype of C<Str>, up to 100 characters.
+Subtype of C<Str>, cannot be an empty string.
 
 =type Max2048CharsStr
 
@@ -339,4 +339,3 @@ object, where the string is used as L<WWW::Sitemap::XML::Google::Video::Player/"
 no Moose::Util::TypeConstraints;
 
 1;
-


### PR DESCRIPTION
Google's specifications [1] no longer restrict the length of the title.

[1] https://developers.google.com/search/docs/crawling-indexing/sitemaps/video-sitemaps

This fixes #8.